### PR TITLE
fixes bug of not starting if storage is not empty

### DIFF
--- a/assets/javascript/script.js
+++ b/assets/javascript/script.js
@@ -392,7 +392,7 @@ async function assignValueToVariables() {
 };
 
 function requestLocalStorage() {
-    if(localStorage.length > 0) {
+    if(localStorage.getItem("settings") && localStorage.getItem("bestScore")) {
         settings = JSON.parse(localStorage.getItem("settings"));
         bestScore = JSON.parse(localStorage.getItem("bestScore"));
     } else {


### PR DESCRIPTION
When starting the application, if the storage is not empty, it thinks the items are already there when they aren't, and this makes it crash.
![image](https://user-images.githubusercontent.com/42651514/197366752-caf10ff8-52d0-43e3-a272-9f8ddb68e6b4.png)
So instead of verifying the length, it verifies directly the items and prevents this error.